### PR TITLE
Hysteresis and Replacement of "nmap" with "ping"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ This is WiFi Room Sensor plugin for [Homebridge](https://github.com/nfarina/home
         {
           "accessory": "WiFiRoomSensor",
           "name": "WiFi Room Sensor",
-          "ip": "TOKEN_FROM_STEP_3",
+          "ip": "TOKEN_FROM_STEP_2",
           "interval": 30,
-          "hysteresis": 5
+          "hysteresis": 10
         }
       ]
     ```
+    Interval is measured in seconds and hysteresis is measured in minutes.
 
 4. Restart Homebridge, and your WiFi Room Sensor will be added to Home app.
 

--- a/README.md
+++ b/README.md
@@ -11,21 +11,15 @@ This is WiFi Room Sensor plugin for [Homebridge](https://github.com/nfarina/home
 
 
 ### Installation
-1. Install required library.
-
-   ```
-   apt-get install nmap
-   ```
-
-2. Install required packages.
+1. Install required packages.
 
    ```
    npm install -g homebridge-wifi-room-sensor
    ```
 
-3. Check the MAC address and IP address of WiFi Room Sensor.
+2. Check the IP address of WiFi Room Sensor.
 
-4. Add these values to `config.json`.
+3. Add these values to `config.json`.
 
     ```
       "accessories": [
@@ -33,8 +27,8 @@ This is WiFi Room Sensor plugin for [Homebridge](https://github.com/nfarina/home
           "accessory": "WiFiRoomSensor",
           "name": "WiFi Room Sensor",
           "ip": "TOKEN_FROM_STEP_3",
-          "mac": "TOKEN_FROM_STEP_3",
-          "interval": 5000
+          "interval": 30,
+          "hysteresis": 5
         }
       ]
     ```

--- a/example.config.json
+++ b/example.config.json
@@ -11,8 +11,8 @@
 			"accessory": "WiFiRoomSensor",
 			"name": "WiFi Room Sensor",
 			"ip": "192.168.0.2",
-			"mac": "00-00-00-00-00-00",
-			"interval": 5000
+			"interval": 30,
+			"hysteresis": 5
 		}
 	]
 }

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ function WifiRoomSensor(log, config) {
 	this.services = [];
 	this.name = config.name || 'WiFi Room Sensor';
 	this.ip = config.ip;
-	this.interval = Number(config.interval) || 60;
-	this.hysteresis = Number(config.hysteresis) || 5;
+	this.interval = Number(config.interval) || 30;
+	this.hysteresis = Number(config.hysteresis) || 10;
 	this.sensorState = undefined;
 	this.lastSeen = 0;
 


### PR DESCRIPTION
Hi Kim

Would you please merge this pull request?  I have made two adjustments to your original code.
1. I have added a hysteresis.  If the WiFi device is unreachable due to power management, the occupancy sensor now still triggers within a time interval after the WiFi device has been seen last.  That interval is configurable with the value of the field `hysteresis` in the configuration file.  Note that the value is interpreted as minutes.
2. I have replaced the heavy-weight port scanner `nmap` with the simple `ping` tool that should be available on almost all *unix machines.  The search is now much faster.  Was there a reason to use `nmap`?

Please note that `interval` is now measured in seconds (and not milliseconds anymore).

Best,
Francesco